### PR TITLE
Adds optional timeout value for requests

### DIFF
--- a/src/waldur_client.py
+++ b/src/waldur_client.py
@@ -13,6 +13,13 @@ verify_ssl = os.environ.get("REQUESTS_VERIFY_SSL", "true")
 
 verify_ssl = verify_ssl.lower() not in ["false", "no", "0"]
 
+requests_timeout = os.environ.get("REQUESTS_TIMEOUT")
+
+if requests_timeout is not None and requests_timeout.isdigit():
+    requests_timeout = int(requests_timeout)
+else:
+    requests_timeout = None
+
 requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 
 
@@ -258,7 +265,7 @@ class WaldurClient(object):
                 % (method, url, prev_response_data)
             )
 
-        params = dict(headers=self.headers, verify=verify_ssl)
+        params = dict(headers=self.headers, verify=verify_ssl, timeout=requests_timeout)
         params.update(kwargs)
 
         try:
@@ -288,7 +295,7 @@ class WaldurClient(object):
         return ""
 
     def _get_all(self, url, **kwargs):
-        auth_params = dict(headers=self.headers, verify=verify_ssl)
+        auth_params = dict(headers=self.headers, verify=verify_ssl, timeout=requests_timeout)
         params = dict()
         params.update(auth_params)
         params.update(kwargs)


### PR DESCRIPTION
Adds optional environment variable for configuring requests timeout value.
See: https://requests.readthedocs.io/en/latest/api/?highlight=timeout#requests.Session.request